### PR TITLE
feat(/elk): remove /elk need

### DIFF
--- a/haproxy.cfg
+++ b/haproxy.cfg
@@ -21,11 +21,12 @@ frontend router
   acl is_activitypub_request req.hdr(content-type) -i "application/ld+json; profile=\"https://www.w3.org/ns/activitystreams\""
   use_backend streaming if { path_beg /api/v1/streaming }
   use_backend mastodon if is_activitypub_request
-  use_backend mastodon if { path_beg /api }
   use_backend elk if { path_beg /_nuxt }
-  use_backend elk if { path_beg /https://${ROUTER_HOSTNAME-stage.moztodon.nonprod.webservices.mozgcp.net} }
-  use_backend rewrite-to-elk-svrname if { path '/explore' } || { path '/list' } || { path '/local' } || { path '/notifications' } || { path '/public/local' } || { path_beg /@ } || { path_beg /tags }
-  use_backend elk if { path / } || { path /bookmarks } || { path /conversations } || { path /favourites } || { path /home } || { path /public } || { path /publish } || { path '/search' } || { path_beg /settings }
+  use_backend elk if { path_beg /api/${ROUTER_HOSTNAME-stage.moztodon.nonprod.webservices.mozgcp.net} }
+  use_backend mastodon if { path_beg /api }
+  use_backend rewrite-publish if { path '/publish' } || { path_beg /settings/ }
+  use_backend elk if { path / } || { path '/compose' } || { path /settings } || { path /bookmarks } || { path '/conversations' } || { path '/favourites' } || { path '/home' } || { path '/public' } || { path '/search' }
+  use_backend elk if { path_beg /settings }  || { path '/explore' } || { path '/list' } || { path '/local' } || { path '/notifications' } || { path '/public/local' } || { path_beg /@ } || { path_beg /tags }
   use_backend mastodon-legacy-redirs if { path /about/more } || { path /oauth/authorize/native } || { path /web }
   use_backend mastodon 
 
@@ -41,6 +42,11 @@ backend mastodon
 
 backend streaming
   server mastodon "${MASTODON_STREAMING_SERVICE_AND_PORT-streaming.moztodon-stage.svc.cluster.local:4000}" maxconn "${MAXCONN_MASTODON_STREAMING-50}"
+
+backend rewrite-publish
+  http-request replace-path /publish(.*) /compose\1
+  http-request replace-path /settings/.* /settings
+  http-request redirect prefix "https://${ROUTER_HOSTNAME-stage.moztodon.nonprod.webservices.mozgcp.net}"
 
 backend elk
   server elk "${ELK_SERVICE_AND_PORT-elk.elk-stage.svc.cluster.local:8080}" maxconn "${MAXCONN_ELK-50}"

--- a/haproxy.cfg
+++ b/haproxy.cfg
@@ -43,7 +43,6 @@ backend streaming
   server mastodon "${MASTODON_STREAMING_SERVICE_AND_PORT-streaming.moztodon-stage.svc.cluster.local:4000}" maxconn "${MAXCONN_MASTODON_STREAMING-50}"
 
 backend elk
-  server elk "${ELK_SERVICE_AND_PORT-elk.elk-stage.svc.cluster.local:8080}" maxconn "${MAXCONN_ELK-50}"
 
 backend rewrite-to-elk-plain
   server elk "${ELK_SERVICE_AND_PORT-elk.elk-stage.svc.cluster.local:8080}" maxconn "${MAXCONN_ELK-50}"

--- a/haproxy.cfg
+++ b/haproxy.cfg
@@ -46,5 +46,5 @@ backend elk
   server elk "${ELK_SERVICE_AND_PORT-elk.elk-stage.svc.cluster.local:8080}" maxconn "${MAXCONN_ELK-50}"
 
 backend rewrite-to-elk-svrname
-  http-request replace-path (.*) "/elk/${MASTODON_HOSTNAME-stage.moztodon.nonprod.webservices.mozgcp.net}\1"
+  http-request replace-path (.*) "/${MASTODON_HOSTNAME-stage.moztodon.nonprod.webservices.mozgcp.net}\1"
   server elk "${ELK_SERVICE_AND_PORT-elk.elk-stage.svc.cluster.local:8080}" maxconn "${MAXCONN_ELK-50}"

--- a/haproxy.cfg
+++ b/haproxy.cfg
@@ -36,7 +36,7 @@ frontend router
   # Route all these urls to the Elk interface
   use_backend elk if { path / } || { path '/compose' } || { path /settings } || { path /bookmarks } || { path '/conversations' } || { path '/favourites' } || { path '/home' } || { path '/public' } || { path '/search' }
   # secondary line because haproxy doesnt allow more then 240 characters
-  use_backend elk if { path_beg /settings }  || { path '/explore' } || { path '/list' } || { path '/local' } || { path '/notifications' } || { path '/public/local' } || { path_beg /@ } || { path_beg /tags }
+  use_backend elk if { path_beg /settings }  || { path '/explore' } || { path_beg '/list' } || { path '/local' } || { path '/notifications' } || { path '/public/local' } || { path_beg /@ } || { path_beg /tags }
   # Redirect old mastodon urls to new ones
   use_backend mastodon-legacy-redirs if { path /about/more } || { path /oauth/authorize/native } || { path /web }
   # Fall back to mastodon
@@ -57,6 +57,7 @@ backend mastodon
 
 backend streaming
   server mastodon "${MASTODON_STREAMING_SERVICE_AND_PORT-streaming.moztodon-stage.svc.cluster.local:4000}" maxconn "${MAXCONN_MASTODON_STREAMING-50}"
+  http-response set-header X-Server mastodon
 
 backend rewrite-publish
   http-request replace-path /publish(.*) /compose\1
@@ -68,3 +69,4 @@ backend elk
   http-request add-header X-Real-Ip %[src] # Custom header with src IP
   option forwardfor # X-forwarded-for 
   server elk "${ELK_SERVICE_AND_PORT-elk.elk-stage.svc.cluster.local:8080}" maxconn "${MAXCONN_ELK-50}"
+  http-response set-header X-Server elk

--- a/haproxy.cfg
+++ b/haproxy.cfg
@@ -21,9 +21,11 @@ frontend router
   acl is_activitypub_request req.hdr(content-type) -i "application/ld+json; profile=\"https://www.w3.org/ns/activitystreams\""
   use_backend streaming if { path_beg /api/v1/streaming }
   use_backend mastodon if is_activitypub_request
-  use_backend elk if { path_beg /elk }
+  use_backend mastodon if { path_beg /api }
+  use_backend elk if { path_beg /_nuxt }
+  use_backend elk if { path_beg /https://${ROUTER_HOSTNAME-stage.moztodon.nonprod.webservices.mozgcp.net} }
   use_backend rewrite-to-elk-svrname if { path '/explore' } || { path '/list' } || { path '/local' } || { path '/notifications' } || { path '/public/local' } || { path_beg /@ } || { path_beg /tags }
-  use_backend rewrite-to-elk-plain if { path / } || { path /bookmarks } || { path /conversations } || { path /favourites } || { path /home } || { path /public } || { path /publish } || { path '/search' } || { path_beg /settings }
+  use_backend elk if { path / } || { path /bookmarks } || { path /conversations } || { path /favourites } || { path /home } || { path /public } || { path /publish } || { path '/search' } || { path_beg /settings }
   use_backend mastodon-legacy-redirs if { path /about/more } || { path /oauth/authorize/native } || { path /web }
   use_backend mastodon 
 
@@ -44,11 +46,8 @@ backend elk
   server elk "${ELK_SERVICE_AND_PORT-elk.elk-stage.svc.cluster.local:8080}" maxconn "${MAXCONN_ELK-50}"
 
 backend rewrite-to-elk-plain
-  http-request replace-path (.*) /elk\1
-  http-request replace-path /elk/publish(.*) /elk/compose\1
-  http-request replace-path /elk/settings/.* /elk/settings
-  http-request redirect prefix "https://${ROUTER_HOSTNAME-stage.moztodon.nonprod.webservices.mozgcp.net}"
+  server elk "${ELK_SERVICE_AND_PORT-elk.elk-stage.svc.cluster.local:8080}" maxconn "${MAXCONN_ELK-50}"
 
 backend rewrite-to-elk-svrname
   http-request replace-path (.*) "/elk/${MASTODON_HOSTNAME-stage.moztodon.nonprod.webservices.mozgcp.net}\1"
-  http-request redirect prefix "https://${ROUTER_HOSTNAME-stage.moztodon.nonprod.webservices.mozgcp.net}"
+  server elk "${ELK_SERVICE_AND_PORT-elk.elk-stage.svc.cluster.local:8080}" maxconn "${MAXCONN_ELK-50}"

--- a/haproxy.cfg
+++ b/haproxy.cfg
@@ -43,7 +43,6 @@ backend streaming
   server mastodon "${MASTODON_STREAMING_SERVICE_AND_PORT-streaming.moztodon-stage.svc.cluster.local:4000}" maxconn "${MAXCONN_MASTODON_STREAMING-50}"
 
 backend elk
-
 backend rewrite-to-elk-plain
   server elk "${ELK_SERVICE_AND_PORT-elk.elk-stage.svc.cluster.local:8080}" maxconn "${MAXCONN_ELK-50}"
 

--- a/haproxy.cfg
+++ b/haproxy.cfg
@@ -43,7 +43,6 @@ backend streaming
   server mastodon "${MASTODON_STREAMING_SERVICE_AND_PORT-streaming.moztodon-stage.svc.cluster.local:4000}" maxconn "${MAXCONN_MASTODON_STREAMING-50}"
 
 backend elk
-backend rewrite-to-elk-plain
   server elk "${ELK_SERVICE_AND_PORT-elk.elk-stage.svc.cluster.local:8080}" maxconn "${MAXCONN_ELK-50}"
 
 backend rewrite-to-elk-svrname

--- a/haproxy.cfg
+++ b/haproxy.cfg
@@ -19,15 +19,25 @@ frontend router
 
   # route to a backend based on path's prefix and content-type header
   acl is_activitypub_request req.hdr(content-type) -i "application/ld+json; profile=\"https://www.w3.org/ns/activitystreams\""
+  # Make sure the streaming api is routed to mastodons streaming socket
   use_backend streaming if { path_beg /api/v1/streaming }
+  # Go to mastodon if its an apub request
   use_backend mastodon if is_activitypub_request
-  use_backend elk if { path_beg /_nuxt }
-  use_backend elk if { path_beg /api/${ROUTER_HOSTNAME-stage.moztodon.nonprod.webservices.mozgcp.net} }
+  # Elk Asset files
+  use_backend elk if { path_beg /_nuxt } || { path_beg /avatars } || { path_beg /emojis } || { path_beg /fonts } || { path_beg /shiki } || { path '/favicon.ico' } || { path '/logo.svg' } || { path '/apple-touch-icon.png' }
+  #Elk internal API
+  use_backend elk if { path_beg /api/${ROUTER_HOSTNAME-stage.moztodon.nonprod.webservices.mozgcp.net} } || { path_beg /api/list-servers }
+  # All other apis should go to mastodon
   use_backend mastodon if { path_beg /api }
+  # Rewrite some urls to our own
   use_backend rewrite-publish if { path '/publish' } || { path_beg /settings/ }
+  # Route all these urls to the Elk interface
   use_backend elk if { path / } || { path '/compose' } || { path /settings } || { path /bookmarks } || { path '/conversations' } || { path '/favourites' } || { path '/home' } || { path '/public' } || { path '/search' }
+  # secondary line because haproxy doesnt allow more then 240 characters
   use_backend elk if { path_beg /settings }  || { path '/explore' } || { path '/list' } || { path '/local' } || { path '/notifications' } || { path '/public/local' } || { path_beg /@ } || { path_beg /tags }
+  # Redirect old mastodon urls to new ones
   use_backend mastodon-legacy-redirs if { path /about/more } || { path /oauth/authorize/native } || { path /web }
+  # Fall back to mastodon
   use_backend mastodon 
 
 backend mastodon-legacy-redirs
@@ -49,8 +59,4 @@ backend rewrite-publish
   http-request redirect prefix "https://${ROUTER_HOSTNAME-stage.moztodon.nonprod.webservices.mozgcp.net}"
 
 backend elk
-  server elk "${ELK_SERVICE_AND_PORT-elk.elk-stage.svc.cluster.local:8080}" maxconn "${MAXCONN_ELK-50}"
-
-backend rewrite-to-elk-svrname
-  http-request replace-path (.*) "/${MASTODON_HOSTNAME-stage.moztodon.nonprod.webservices.mozgcp.net}\1"
   server elk "${ELK_SERVICE_AND_PORT-elk.elk-stage.svc.cluster.local:8080}" maxconn "${MAXCONN_ELK-50}"

--- a/haproxy.cfg
+++ b/haproxy.cfg
@@ -24,9 +24,11 @@ frontend router
   # Go to mastodon if its an apub request
   use_backend mastodon if is_activitypub_request
   # Elk Asset files
-  use_backend elk if { path_beg /_nuxt } || { path_beg /avatars } || { path_beg /emojis } || { path_beg /fonts } || { path_beg /shiki } || { path '/favicon.ico' } || { path '/logo.svg' } || { path '/apple-touch-icon.png' }
+  use_backend elk if { path_beg /_nuxt } || { path_beg /__nuxt_error } || { path_beg /avatars } || { path_beg /emojis } || { path_beg /fonts } || { path_beg /shiki } || { path '/favicon.ico' } || { path '/logo.svg' } || { path '/apple-touch-icon.png' } || { path '/manifest.webmanifest' }
   #Elk internal API
   use_backend elk if { path_beg /api/${ROUTER_HOSTNAME-stage.moztodon.nonprod.webservices.mozgcp.net} } || { path_beg /api/list-servers }
+  # Elk sign in URL
+  use_backend elk if { path_beg '/signin/callback' }
   # All other apis should go to mastodon
   use_backend mastodon if { path_beg /api }
   # Rewrite some urls to our own
@@ -48,6 +50,9 @@ backend mastodon-legacy-redirs
 
 backend mastodon
   http-request set-header Host "${MASTODON_HOSTNAME-stage.moztodon.nonprod.webservices.mozgcp.net}"
+  http-request set-header X-Forwarded-Proto https if { ssl_fc } # For Proto
+  http-request add-header X-Real-Ip %[src] # Custom header with src IP
+  option forwardfor # X-forwarded-for 
   server mastodon "${MASTODON_SERVICE_AND_PORT-web.moztodon-stage.svc.cluster.local:8080}" maxconn "${MAXCONN_MASTODON-50}"
 
 backend streaming
@@ -59,4 +64,7 @@ backend rewrite-publish
   http-request redirect prefix "https://${ROUTER_HOSTNAME-stage.moztodon.nonprod.webservices.mozgcp.net}"
 
 backend elk
+  http-request set-header X-Forwarded-Proto https if { ssl_fc } # For Proto
+  http-request add-header X-Real-Ip %[src] # Custom header with src IP
+  option forwardfor # X-forwarded-for 
   server elk "${ELK_SERVICE_AND_PORT-elk.elk-stage.svc.cluster.local:8080}" maxconn "${MAXCONN_ELK-50}"


### PR DESCRIPTION
## Goal

Clean up urls in the user's browser

## TODO
- [x] Remove elk from the url path (note this requires setting the elk base path to `/`)
- [ ] Update elk to not use `/elk` for deployment  https://github.com/MozillaSocial/elk/pull/11