### PR TITLE
fix(auth): deleting referer header on the proxy to mastodon if it's /auth/sign_in

### DIFF
--- a/haproxy.cfg
+++ b/haproxy.cfg
@@ -49,6 +49,11 @@ backend mastodon-legacy-redirs
   http-request redirect prefix "https://${ROUTER_HOSTNAME-stage.moztodon.nonprod.webservices.mozgcp.net}"
 
 backend mastodon
+  # if the request is the /auth/sign_in intersisteall, we remove the referer header because mastodon usually overrides 
+  # the stored oidc redirect if it was navigated to from the same host domain and theres a referer header
+  # By deleting it here we avoid updating both elk and mastodon code and allow our client to run on the same domain as Mastodon
+  # https://github.com/MozillaSocial/mastodon/blob/main/app/controllers/application_controller.rb#L67
+  http-request del-header referer if { path '/auth/sign_in' }
   http-request set-header Host "${MASTODON_HOSTNAME-stage.moztodon.nonprod.webservices.mozgcp.net}"
   http-request set-header X-Forwarded-Proto https if { ssl_fc } # For Proto
   http-request add-header X-Real-Ip %[src] # Custom header with src IP


### PR DESCRIPTION
## Goal

Upon logging into Mozilla.social with the unified elk system locally on staging, ensure that we redirect to Elk's expected callback url with token information.

Issue:

![ezgif-4-2cc22e8e3d](https://github.com/mozilla-services/mozsocial-haproxy-router/assets/1010384/2f56a3dd-c857-4745-a465-3b0b5d84d5fb)


## Solution
It turns out that Mastodon has code in it to override the redirect url on sign in if the host is the same as the referrer header host. 

To solve for this, we delete the referer header if the request is for the `auth/sign_in` page. Which makes sure we will never hit the code [here](https://github.com/MozillaSocial/mastodon/blob/main/app/controllers/application_controller.rb#L67)

This code exists for if someone is browsing mozilla.social/federated, clicks login and then it ensures they make it back to /federated. In that world there is never the need to store an OIDC callback that the user must be redirected to.

Long term we should also modify elk to save the users current path to a short lived cookie when they click sign in so that we can redirect them back to that path after they are fully authed.