### PR TITLE
fix(logging): enable json logging in haproxy

### DIFF
--- a/haproxy.cfg
+++ b/haproxy.cfg
@@ -8,11 +8,22 @@ defaults
   timeout connect 5000ms
   timeout client 50000ms
   timeout server 50000ms
+  log-format '{"time":"%Tl","remote_addr":"%ci","remote_user":"%[capture.req.hdr(7),json(utf8s)]","request":"%r","status":"%ST","log_type":"access","bytes_sent":"%B","request_time":"%Tr","referrer":"%[capture.req.hdr(2),json(utf8s)]","user_agent":"%[capture.req.hdr(3),json(utf8s)]","x_forwarded_for":"%[capture.req.hdr(1),json(utf8s)]","x_forwarded_proto":"%[capture.req.hdr(5),json(utf8s)]","trace":"%[capture.req.hdr(6),json(utf8s)]"}' 
+
 
 frontend router
   bind :8080
   log global
-  option httplog
+
+  # Note order matters, we pull this based on index in the log format
+  capture request header Host len 200
+  capture request header X-Forwarded-For len 200
+  capture request header Referer len 200
+  capture request header User-Agent len 200
+  capture request header RemoteAddr len 200
+  capture request header X-Forwarded-Proto len 5
+  capture request header x-cloud-trace-context len 200
+  capture request header RemoteUser len 200
 
   # "health" checks
   http-request return status 200 content-type text/plain string ok if { path /__nginxheartbeat__ } || { path /__lbheartbeat__ }


### PR DESCRIPTION
## Goal

Set up HAProxy to log via JSON matching our NGinx configuration

```
{"time":"03/Aug/2023:17:57:42 +0000","remote_addr":"172.25.0.1","remote_user":"-","request":"GET https://mozsoc.local/_nuxt/components/list/ListEntry.vue HTTP/2.0","status":"304","log_type":"access","bytes_sent":"124","request_time":"1","referrer":"https:\/\/mozsoc.local\/_nuxt\/pages\/[[server]]\/lists.vue","user_agent":"Mozilla\/5.0 (Macintosh; Intel Mac OS X 10.15; rv:109.0) Gecko\/20100101 Firefox\/116.0","x_forwarded_for":"-","x_forwarded_proto":"-","trace":"-"}
```