### PR TITLE
allow /settings/applications to go to mastodon

### DIFF
--- a/haproxy.cfg
+++ b/haproxy.cfg
@@ -49,6 +49,8 @@ frontend router
   use_backend invitation if { path_beg /api/invitation }
   # All other apis should go to mastodon
   use_backend mastodon if { path_beg /api }
+  # specific /settings to allow for mastodon
+  use_backend mastodon if { path_beg /settings/applications }
   # Rewrite some urls to our own
   use_backend rewrite-publish if { path '/publish' } || { path_beg /settings/ }
   # Route all these urls to the Elk interface


### PR DESCRIPTION
I need to set up api keys for, like, the cinder-mastodon-bridge, which requires getting to /settings/applications on mastodon