### PR TITLE
feat(routes): adding route for the new discover page [SOC-122]

### DIFF
--- a/haproxy.cfg
+++ b/haproxy.cfg
@@ -56,7 +56,7 @@ frontend router
   # Rewrite some urls to our own
   use_backend rewrite-publish if { path '/publish' } || { path_beg /settings/ }
   # Route all these urls to the Elk interface
-  use_backend elk if { path / } || { path '/compose' } || { path /settings } || { path /bookmarks } || { path '/conversations' } || { path '/favourites' } || { path '/home' } || { path '/public' } || { path '/search' }
+  use_backend elk if { path / } || { path '/compose' } || { path /settings } || { path /bookmarks } || { path '/conversations' } || { path '/favourites' } || { path '/home' } || { path '/public' } || { path '/search' } || { path '/discover' }
   # secondary line because haproxy doesnt allow more then 240 characters
   use_backend elk if { path_beg /settings }  || { path '/explore' } || { path_beg '/list' } || { path '/local' } || { path '/notifications' } || { path '/public/local' } || { path_beg /@ } || { path_beg /tags }
   # Redirect old mastodon urls to new ones
@@ -81,7 +81,7 @@ backend cmbridge
   http-request redirect location "https://${CMBRIDGE_HOSTNAME-stage.cm-bridge.nonprod.webservices.mozgcp.net}/infringement-form"
 
 backend mastodon
-  # if the request is the /auth/sign_in intersisteall, we remove the referer header because mastodon usually overrides 
+  # if the request is the /auth/sign_in intersisteall, we remove the referer header because mastodon usually overrides
   # the stored oidc redirect if it was navigated to from the same host domain and theres a referer header
   # By deleting it here we avoid updating both elk and mastodon code and allow our client to run on the same domain as Mastodon
   # https://github.com/MozillaSocial/mastodon/blob/main/app/controllers/application_controller.rb#L67

--- a/haproxy.cfg
+++ b/haproxy.cfg
@@ -56,9 +56,11 @@ frontend router
   # Rewrite some urls to our own
   use_backend rewrite-publish if { path '/publish' } || { path_beg /settings/ }
   # Route all these urls to the Elk interface
-  use_backend elk if { path / } || { path '/compose' } || { path /settings } || { path /bookmarks } || { path '/conversations' } || { path '/favourites' } || { path '/home' } || { path '/public' } || { path '/search' } || { path '/discover' }
+  use_backend elk if { path / } || { path '/compose' } || { path /settings } || { path /bookmarks } || { path '/conversations' } || { path '/favourites' } || { path '/home' } || { path '/public' } || { path '/search' }
   # secondary line because haproxy doesnt allow more then 240 characters
   use_backend elk if { path_beg /settings }  || { path '/explore' } || { path_beg '/list' } || { path '/local' } || { path '/notifications' } || { path '/public/local' } || { path_beg /@ } || { path_beg /tags }
+  # third line because haproxy doesnt allow more then 240 characters
+  use_backend elk if { path '/discover' }
   # Redirect old mastodon urls to new ones
   use_backend mastodon-legacy-redirs if { path /about/more } || { path /oauth/authorize/native } || { path /web }
   # Fall back to mastodon

--- a/tests/index.js
+++ b/tests/index.js
@@ -241,6 +241,12 @@ describe('MozSoc URL mapping', () => {
       assert.equal(req.status, 200);
       assert.equal(req.headers.get('x-server'), 'elk');
     });
+
+    it('discover', async () => {
+      const req = await request('discover');
+      assert.equal(req.status, 200);
+      assert.equal(req.headers.get('x-server'), 'elk');
+    });
   });
 
   describe('Mastodon deprecated', async () => {


### PR DESCRIPTION
Adding a new route for `/discover` to support the upcoming work to surface recommendations to users.

[Jira Ticket](https://mozilla-hub.atlassian.net/browse/SOC-122)

Here's a screenshot of the new page:
![image](https://github.com/mozilla-services/mozsocial-haproxy-router/assets/1273879/c9ae0b05-08a7-4d7c-94a3-69dbaa8187c7)
