### PR TITLE
feat(route): Add /content-feed for Content Feed Service [MC-161]

### DIFF
--- a/haproxy.cfg
+++ b/haproxy.cfg
@@ -118,8 +118,9 @@ backend elk
 
 backend content-feed
   http-request replace-path /content-feed(.*) \1
+  http-request set-header Host "${CONTENT_FEED_HOSTNAME-stage.content-feed-service.nonprod.webservices.mozgcp.net}"
   http-request set-header X-Forwarded-Proto https if { ssl_fc } # For Proto
   http-request add-header X-Real-Ip %[src] # Custom header with src IP
   option forwardfor if-none # X-forwarded-for
-  server content_feed "${CONTENT_FEED_HOSTNAME-stage.content-feed-service.nonprod.webservices.mozgcp.net}"
+  server content_feed "${CONTENT_FEED_SERVICE_AND_PORT-content-feed-service.content-feed-service-stage.svc.cluster.local:8080}" maxconn "$MAXCONN_CONTENT_FEED-50}"
   http-response set-header X-Server content-feed

--- a/haproxy.cfg
+++ b/haproxy.cfg
@@ -49,6 +49,8 @@ frontend router
   use_backend invitation if { path_beg /api/invitation }
   # Cinder-Mastodon Bridge microservice
   use_backend cmbridge if { path_beg /en-US/about/legal/report-infringement-form }
+  # Content Feed API
+  use_backend content-feed if { path_beg /content-feed }
   # All other apis should go to mastodon
   use_backend mastodon if { path_beg /api }
   # specific /settings to allow for mastodon
@@ -113,3 +115,11 @@ backend elk
   option forwardfor if-none # X-forwarded-for
   server elk "${ELK_SERVICE_AND_PORT-elk.elk-stage.svc.cluster.local:8080}" maxconn "${MAXCONN_ELK-50}"
   http-response set-header X-Server elk
+
+backend content-feed
+  http-request replace-path /content-feed(.*) \1
+  http-request set-header X-Forwarded-Proto https if { ssl_fc } # For Proto
+  http-request add-header X-Real-Ip %[src] # Custom header with src IP
+  option forwardfor if-none # X-forwarded-for
+  server content_feed "${CONTENT_FEED_HOSTNAME-stage.content-feed-service.nonprod.webservices.mozgcp.net}"
+  http-response set-header X-Server content-feed

--- a/tests/index.js
+++ b/tests/index.js
@@ -249,6 +249,28 @@ describe('MozSoc URL mapping', () => {
     });
   });
 
+  describe('Content-Feed', async () => {
+    it('moso/v1/discover 200', async () => {
+      const req = await request('content-feed/moso/v1/discover?locale=en-US');
+      assert.equal(req.status, 200);
+      assert.equal(
+        req.headers.get('content-type'),
+        'application/json; charset=utf-8'
+      );
+      assert.equal(req.headers.get('x-server'), 'content-feed');
+    });
+
+    it('moso/v1/discover 400 for missing query parameter', async () => {
+      const req = await request('content-feed/moso/v1/discover');
+      assert.equal(req.status, 400);
+    });
+
+    it('responds with 404 on a non-existing path', async () => {
+      const req = await request('content-feed/does-not-exist');
+      assert.equal(req.status, 404);
+    });
+  });
+
   describe('Mastodon deprecated', async () => {
     it('user/@foo/followers', async () => {
       const req = await request('user/@foo/followers');


### PR DESCRIPTION
# Goal
[MC-161](https://mozilla-hub.atlassian.net/browse/MC-161) Add a route for https://github.com/MozillaSocial/content-feed-service. 

Currently it has one endpoint: https://stage.content-feed-service.nonprod.webservices.mozgcp.net/moso/v1/discover?locale=en-US. Query parameters will definitely change in the coming months. Probably we will add different paths in the future prefixed with /moso.