### PR TITLE
Use Mastodon for /settings fallback instead of Elk

### DIFF
--- a/haproxy.cfg
+++ b/haproxy.cfg
@@ -53,16 +53,16 @@ frontend router
   use_backend content-feed if { path_beg /content-feed }
   # All other apis should go to mastodon
   use_backend mastodon if { path_beg /api }
-  # specific /settings to allow for mastodon
-  use_backend mastodon if { path_beg /settings/applications } || { path_beg /settings/migration } || { path_beg /settings/aliases } || { path /settings/delete }
+  # specific /settings to allow for elk (rest should go to mastodon)
+  use_backend elk if { path /settings } || { path_beg /settings/profile } || { path /settings/interface } || { path_beg /settings/notifications } || { path /settings/language }  || { path /settings/preferences }
   # Rewrite some urls to our own
-  use_backend rewrite-publish if { path '/publish' } || { path_beg /settings/ }
+  use_backend rewrite-publish if { path '/publish' }
   # Route all these urls to the Elk interface
   use_backend elk if { path / } || { path '/compose' } || { path /settings } || { path /bookmarks } || { path '/conversations' } || { path '/favourites' } || { path '/home' } || { path '/public' } || { path '/search' }
   # secondary line because haproxy doesnt allow more then 240 characters
-  use_backend elk if { path_beg /settings }  || { path '/explore' } || { path_beg '/list' } || { path '/local' } || { path '/notifications' } || { path '/public/local' } || { path_beg /@ } || { path_beg /tags }
-  # third line because haproxy doesnt allow more then 240 characters
-  use_backend elk if { path '/discover' }
+  use_backend elk if { path '/explore' } || { path '/discover' } || { path_beg '/list' } || { path '/local' } || { path '/notifications' } || { path '/public/local' } || { path_beg /@ } || { path_beg /tags }
+  # TEMP: prepare for invites; prevent access to mastodon invites page since it doesn't do anything on our instance
+  use_backend elk if { path '/invites' }
   # Redirect old mastodon urls to new ones
   use_backend mastodon-legacy-redirs if { path /about/more } || { path /oauth/authorize/native } || { path /web }
   # Fall back to mastodon
@@ -106,7 +106,6 @@ backend streaming
 
 backend rewrite-publish
   http-request replace-path /publish(.*) /compose\1
-  http-request replace-path /settings/.* /settings
   http-request redirect prefix "https://${ROUTER_HOSTNAME-stage.moztodon.nonprod.webservices.mozgcp.net}"
 
 backend elk


### PR DESCRIPTION
Also:
- `/discover` no longer has its own line
- `/invites` goes to Elk instead of Mastodon (temporary for now, could be permanent)

https://mozilla-hub.atlassian.net/browse/SOCIALPLAT-720